### PR TITLE
Entry storage test cases

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(src main.cpp ${SOURCE_FILES})
 target_link_libraries(src sqlite3 cryptopp)
 
 add_executable(test_main tests/test_main.cpp ${SOURCE_FILES})
-target_link_libraries(test_main sqlite3 cryptopp gtest_main)
+target_link_libraries(test_main sqlite3 cryptopp gtest_main gmock_main)
 
 include(GoogleTest)
 gtest_discover_tests(test_main)

--- a/src/adapters/database/DatabaseInterface.cpp
+++ b/src/adapters/database/DatabaseInterface.cpp
@@ -1,4 +1,5 @@
 #include "DatabaseInterface.h"
+#include <stdexcept>
 
 using namespace Adapters::Database;
 
@@ -6,7 +7,9 @@ DDD::Entities::Entry DatabaseInterface::getEntry(const DDD::ValueObjects::EntryI
 {
     std::string sql = "SELECT * FROM passwords WHERE EntryId = \"" + std::to_string(entryId.getInt()) + "\";";
     auto [entrySet, error] = db->executeSql(sql);
-    return *entrySet.begin();
+    if (!entrySet.empty())
+        return *entrySet.begin();
+    throw std::domain_error("no Entry with provided ID");
 }
 
 std::set<DDD::Entities::Entry> DatabaseInterface::getEntries(const DDD::ValueObjects::EntryName &entryName) const

--- a/src/application/AbstractDatabaseInterface.h
+++ b/src/application/AbstractDatabaseInterface.h
@@ -13,8 +13,7 @@ public:
     virtual std::set<DDD::Entities::Entry> getAllEntries() const = 0;
     virtual bool insertEntry(const DDD::Entities::Entry &entry) const = 0;
     virtual bool removeEntry(const DDD::ValueObjects::EntryId &entryId) const = 0;
-    virtual bool
-    modifyEntry(const DDD::ValueObjects::EntryId &entryId, const DatabaseColumn &column, const std::string &newValue) const = 0;
+    virtual bool modifyEntry(const DDD::ValueObjects::EntryId &entryId, const DatabaseColumn &column, const std::string &newValue) const = 0;
 };
 
 #endif //SRC_ABSTRACTDATABASEINTERFACE_H

--- a/src/tests/adapters/database/AbstractSqlDatabaseMock.h
+++ b/src/tests/adapters/database/AbstractSqlDatabaseMock.h
@@ -1,0 +1,22 @@
+#ifndef SRC_ABSTRACTSQLDATABASEMOCK_H
+#define SRC_ABSTRACTSQLDATABASEMOCK_H
+
+#include "../../../adapters/database/AbstractSqlDatabase.h"
+#include <set>
+
+using namespace DDD;
+
+class AbstractSqlDatabaseMock : public Adapters::Database::AbstractSqlDatabase
+{
+public:
+    std::pair<std::set<DDD::Entities::Entry>, std::string> executeSql(const std::string& statement) const override
+    {
+        std::set<Entities::Entry> returnSet;
+        Entities::Entry testEntry(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("TestPassword"));
+        if (statement == "SELECT * FROM passwords WHERE EntryId = \"1\";")
+            returnSet.emplace(testEntry);
+        return std::make_pair(returnSet, "");
+    }
+};
+
+#endif //SRC_ABSTRACTSQLDATABASEMOCK_H

--- a/src/tests/adapters/database/AbstractSqlDatabaseMock.h
+++ b/src/tests/adapters/database/AbstractSqlDatabaseMock.h
@@ -3,20 +3,14 @@
 
 #include "../../../adapters/database/AbstractSqlDatabase.h"
 #include <set>
+#include <gmock/gmock.h>
 
 using namespace DDD;
 
 class AbstractSqlDatabaseMock : public Adapters::Database::AbstractSqlDatabase
 {
 public:
-    std::pair<std::set<DDD::Entities::Entry>, std::string> executeSql(const std::string& statement) const override
-    {
-        std::set<Entities::Entry> returnSet;
-        Entities::Entry testEntry(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("TestPassword"));
-        if (statement == "SELECT * FROM passwords WHERE EntryId = \"1\";")
-            returnSet.emplace(testEntry);
-        return std::make_pair(returnSet, "");
-    }
+    MOCK_METHOD((std::pair<std::set<DDD::Entities::Entry>, std::string>), executeSql, (const std::string& statement), (const, override));
 };
 
 #endif //SRC_ABSTRACTSQLDATABASEMOCK_H

--- a/src/tests/adapters/database/databaseInterface_tests.cpp
+++ b/src/tests/adapters/database/databaseInterface_tests.cpp
@@ -2,8 +2,12 @@
 #include "AbstractSqlDatabaseMock.h"
 #include "../../../adapters/database/DatabaseInterface.h"
 
+using testing::Return;
+
 TEST(GetEntry, AdapterTests) {
     AbstractSqlDatabaseMock abstractDbMock;
+    std::set<DDD::Entities::Entry> nonEmptyEntrySet{Entities::Entry(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("TestPassword"))};
+    EXPECT_CALL(abstractDbMock, executeSql("SELECT * FROM passwords WHERE EntryId = \"1\";")).Times(1).WillOnce(Return(std::make_pair(nonEmptyEntrySet, "")));
     Adapters::Database::DatabaseInterface dbInterface(&abstractDbMock);
 
     Entities::Entry entry = dbInterface.getEntry(ValueObjects::EntryId(1));
@@ -13,6 +17,8 @@ TEST(GetEntry, AdapterTests) {
 
 TEST(GetInvalidEntry, AdapterTests) {
     AbstractSqlDatabaseMock abstractDbMock;
+    std::set<DDD::Entities::Entry> emptyEntrySet;
+    EXPECT_CALL(abstractDbMock, executeSql("SELECT * FROM passwords WHERE EntryId = \"2\";")).Times(1).WillOnce(Return(std::make_pair(emptyEntrySet, "")));
     Adapters::Database::DatabaseInterface dbInterface(&abstractDbMock);
 
     ValueObjects::EntryId invalidId(2);

--- a/src/tests/adapters/database/databaseInterface_tests.cpp
+++ b/src/tests/adapters/database/databaseInterface_tests.cpp
@@ -2,11 +2,19 @@
 #include "AbstractSqlDatabaseMock.h"
 #include "../../../adapters/database/DatabaseInterface.h"
 
-TEST(GetEntryTest, BasicAssertions) {
+TEST(GetEntry, AdapterTests) {
     AbstractSqlDatabaseMock abstractDbMock;
     Adapters::Database::DatabaseInterface dbInterface(&abstractDbMock);
 
     Entities::Entry entry = dbInterface.getEntry(ValueObjects::EntryId(1));
 
     EXPECT_EQ("TestPassword", entry.encryptedPassword.getString());
+}
+
+TEST(GetInvalidEntry, AdapterTests) {
+    AbstractSqlDatabaseMock abstractDbMock;
+    Adapters::Database::DatabaseInterface dbInterface(&abstractDbMock);
+
+    ValueObjects::EntryId invalidId(2);
+    EXPECT_THROW(dbInterface.getEntry(invalidId), std::domain_error);
 }

--- a/src/tests/adapters/database/test_databaseInterface.cpp
+++ b/src/tests/adapters/database/test_databaseInterface.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include "AbstractSqlDatabaseMock.h"
+#include "../../../adapters/database/DatabaseInterface.h"
+
+TEST(GetEntryTest, BasicAssertions) {
+    AbstractSqlDatabaseMock abstractDbMock;
+    Adapters::Database::DatabaseInterface dbInterface(&abstractDbMock);
+
+    Entities::Entry entry = dbInterface.getEntry(ValueObjects::EntryId(1));
+
+    EXPECT_EQ("TestPassword", entry.encryptedPassword.getString());
+}

--- a/src/tests/application/DDD/AbstractDatabaseInterfaceMock.h
+++ b/src/tests/application/DDD/AbstractDatabaseInterfaceMock.h
@@ -2,29 +2,16 @@
 #define SRC_ABSTRACTDATABASEINTERFACEMOCK_H
 
 #include "../../../application/AbstractDatabaseInterface.h"
+#include <gmock/gmock.h>
 
 class AbstractDatabaseInterfaceMock : public AbstractDatabaseInterface {
 public:
-    DDD::Entities::Entry getEntry(const DDD::ValueObjects::EntryId &entryId) const
-    {
-        if (entryId == ValueObjects::EntryId(1))
-            return Entities::Entry(entryId, ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
-        throw std::domain_error("no Entry with provided ID");
-    }
-
-    std::set<DDD::Entities::Entry> getEntries(const DDD::ValueObjects::EntryName &entryName) const
-    {
-        std::set<Entities::Entry> entries;
-        if (entryName == ValueObjects::EntryName("TestEntry")) {
-            entries.emplace(ValueObjects::EntryId(1), entryName, ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
-            entries.emplace(ValueObjects::EntryId(2), entryName, ValueObjects::Login("AnotherTestLogin"), ValueObjects::EncryptedPassword("AnotherEncryptedPassword"));
-        }
-        return entries;
-    }
-    std::set<DDD::Entities::Entry> getAllEntries() const { return std::set<Entities::Entry>(); }
-    bool insertEntry(const DDD::Entities::Entry &entry) const { return false; }
-    bool removeEntry(const DDD::ValueObjects::EntryId &entryId) const { return false; }
-    bool modifyEntry(const DDD::ValueObjects::EntryId &entryId, const DatabaseColumn &column, const std::string &newValue) const { return false; }
+    MOCK_METHOD(DDD::Entities::Entry, getEntry, (const DDD::ValueObjects::EntryId &entryId), (const, override));
+    MOCK_METHOD(std::set<DDD::Entities::Entry>, getEntries, (const DDD::ValueObjects::EntryName &entryName), (const, override));
+    MOCK_METHOD(std::set<DDD::Entities::Entry>, getAllEntries, (), (const, override));
+    MOCK_METHOD(bool, insertEntry, (const DDD::Entities::Entry &entry), (const, override));
+    MOCK_METHOD(bool, removeEntry, (const DDD::ValueObjects::EntryId &entryId), (const, override));
+    MOCK_METHOD(bool, modifyEntry, (const DDD::ValueObjects::EntryId &entryId, const DatabaseColumn &column, const std::string &newValue), (const, override));
 };
 
 

--- a/src/tests/application/DDD/AbstractDatabaseInterfaceMock.h
+++ b/src/tests/application/DDD/AbstractDatabaseInterfaceMock.h
@@ -1,0 +1,31 @@
+#ifndef SRC_ABSTRACTDATABASEINTERFACEMOCK_H
+#define SRC_ABSTRACTDATABASEINTERFACEMOCK_H
+
+#include "../../../application/AbstractDatabaseInterface.h"
+
+class AbstractDatabaseInterfaceMock : public AbstractDatabaseInterface {
+public:
+    DDD::Entities::Entry getEntry(const DDD::ValueObjects::EntryId &entryId) const
+    {
+        if (entryId == ValueObjects::EntryId(1))
+            return Entities::Entry(entryId, ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
+        throw std::domain_error("no Entry with provided ID");
+    }
+
+    std::set<DDD::Entities::Entry> getEntries(const DDD::ValueObjects::EntryName &entryName) const
+    {
+        std::set<Entities::Entry> entries;
+        if (entryName == ValueObjects::EntryName("TestEntry")) {
+            entries.emplace(ValueObjects::EntryId(1), entryName, ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
+            entries.emplace(ValueObjects::EntryId(2), entryName, ValueObjects::Login("AnotherTestLogin"), ValueObjects::EncryptedPassword("AnotherEncryptedPassword"));
+        }
+        return entries;
+    }
+    std::set<DDD::Entities::Entry> getAllEntries() const { return std::set<Entities::Entry>(); }
+    bool insertEntry(const DDD::Entities::Entry &entry) const { return false; }
+    bool removeEntry(const DDD::ValueObjects::EntryId &entryId) const { return false; }
+    bool modifyEntry(const DDD::ValueObjects::EntryId &entryId, const DatabaseColumn &column, const std::string &newValue) const { return false; }
+};
+
+
+#endif //SRC_ABSTRACTDATABASEINTERFACEMOCK_H

--- a/src/tests/application/DDD/encryptor_tests.cpp
+++ b/src/tests/application/DDD/encryptor_tests.cpp
@@ -14,7 +14,7 @@ TEST(PasswordEncryptionService, DDDTests) {
     PasswordEncryptor passwordEncryptor = PasswordEncryptor(cipher, masterPassword);
 
     const PlaintextPassword plaintext = PlaintextPassword("Plaintext");
-    const EncryptedPassword ciphertext = passwordEncryptor.encrypt(plaintext);
+    const ValueObjects::EncryptedPassword ciphertext = passwordEncryptor.encrypt(plaintext);
 
     PasswordDecryptor passwordDecryptor = PasswordDecryptor(cipher, masterPassword);
     const PlaintextPassword decryptedCiphertext = passwordDecryptor.decrypt(ciphertext);

--- a/src/tests/application/DDD/factory_tests.cpp
+++ b/src/tests/application/DDD/factory_tests.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "../../../application/DDD/EntryFactory.h"
+
+TEST(CreateEntry, DDDTests) {
+    Entities::Entry actual = Factories::EntryFactory::createEntry(1, "TestEntry", "TestLogin", "SomeEncryptedPassword");
+    Entities::Entry expected(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
+
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(CreateWrongEntry, DDDTests) {
+    Entities::Entry actual = Factories::EntryFactory::createEntry(2, "TestEntry2", "TestLogin", "SomeEncryptedPassword");
+    Entities::Entry notExpected(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
+
+    EXPECT_NE(notExpected, actual);
+}

--- a/src/tests/application/DDD/repository_tests.cpp
+++ b/src/tests/application/DDD/repository_tests.cpp
@@ -4,9 +4,11 @@
 
 TEST(GetEntry, DDDTests) {
     AbstractDatabaseInterfaceMock mock;
+    Entities::Entry expected(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("TestPassword"));
+    EXPECT_CALL(mock, getEntry(ValueObjects::EntryId(1))).Times(1).WillOnce(Return(expected));
+
     Repositories::EntryRepository repo(&mock);
 
-    Entities::Entry expected(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
     Entities::Entry actual = repo.getEntry(ValueObjects::EntryId(1));
 
     EXPECT_EQ(expected, actual);
@@ -14,6 +16,12 @@ TEST(GetEntry, DDDTests) {
 
 TEST(FindWithName, DDDTests) {
     AbstractDatabaseInterfaceMock mock;
+    std::set<Entities::Entry> entries;
+    ValueObjects::EntryName entryName("TestEntry");
+    entries.emplace(ValueObjects::EntryId(1), entryName, ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
+    entries.emplace(ValueObjects::EntryId(2), entryName, ValueObjects::Login("AnotherTestLogin"), ValueObjects::EncryptedPassword("AnotherEncryptedPassword"));
+    EXPECT_CALL(mock, getEntries(ValueObjects::EntryName("TestEntry"))).Times(1).WillOnce(Return(entries));
+
     Repositories::EntryRepository repo(&mock);
 
     EXPECT_EQ(2, repo.find(ValueObjects::EntryName("TestEntry")).size());

--- a/src/tests/application/DDD/repository_tests.cpp
+++ b/src/tests/application/DDD/repository_tests.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "AbstractDatabaseInterfaceMock.h"
+#include "../../../application/DDD/EntryRepository.h"
+
+TEST(GetEntry, DDDTests) {
+    AbstractDatabaseInterfaceMock mock;
+    Repositories::EntryRepository repo(&mock);
+
+    Entities::Entry expected(ValueObjects::EntryId(1), ValueObjects::EntryName("TestEntry"), ValueObjects::Login("TestLogin"), ValueObjects::EncryptedPassword("SomeEncryptedPassword"));
+    Entities::Entry actual = repo.getEntry(ValueObjects::EntryId(1));
+
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(FindWithName, DDDTests) {
+    AbstractDatabaseInterfaceMock mock;
+    Repositories::EntryRepository repo(&mock);
+
+    EXPECT_EQ(2, repo.find(ValueObjects::EntryName("TestEntry")).size());
+}

--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -2,3 +2,4 @@
 #include "./adapters/database/databaseInterface_tests.cpp"
 #include "./application/DDD/encryptor_tests.cpp"
 #include "./application/DDD/factory_tests.cpp"
+#include "./application/DDD/repository_tests.cpp"

--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "./plugins/encryption/crypto_tests.cpp"
+#include "./adapters/database/test_databaseInterface.cpp"
 #include "./application/DDD/encryptor_tests.cpp"
 
 TEST(HelloTest, BasicAssertions) {

--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -1,11 +1,4 @@
-#include <gtest/gtest.h>
-
 #include "./plugins/encryption/crypto_tests.cpp"
-#include "./adapters/database/test_databaseInterface.cpp"
+#include "./adapters/database/databaseInterface_tests.cpp"
 #include "./application/DDD/encryptor_tests.cpp"
-
-TEST(HelloTest, BasicAssertions) {
-    EXPECT_STRNE("Hello", "world");
-
-    EXPECT_EQ(7*6, 42);
-}
+#include "./application/DDD/factory_tests.cpp"


### PR DESCRIPTION
Adds test cases for DatabaseInterface, EntryRepository and EntryFactory. I implemented the mocks myself instead of using a framework because I wanted to implement some simple control structures therefore making the output of the mocked method dependent on the input.
I'm merging it to this branch instead of the master branch because I rebased from this branch in order to copy the folder structure and your configuration inside the CMakeLists.txt.